### PR TITLE
ci: harden workflow security per supply chain audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,20 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
+
+permissions:
+  contents: read
 
 jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
         with:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm audit --audit-level=high
       - run: npm run build


### PR DESCRIPTION
- Pin actions/checkout and actions/setup-node to full commit SHAs
- Add explicit permissions: contents: read
- Add npm audit --audit-level=high step
- Extend PR trigger to cover develop branch (aligns with Dependabot target)